### PR TITLE
Display Mob Spawner Type when Holding/Clicking a spawner (Before its placed)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,12 @@
 # See documentation at http://dev.bukkit.org/server-mods/silkspawners/
 
+# Set to false to not use spout features even if spout is present
+useSpout: true
+# Whether to notify a player the spawner type when clicking a spawner in inventory
+notifyOnClick: true
+# Whether to notify a player the spawner type when holding a spawner
+notifyOnHold: true
+
 consumeEgg: true
 usePermissions: false
 useWorldGuard: true

--- a/plugin.yml
+++ b/plugin.yml
@@ -3,6 +3,7 @@ main: me.exphc.SilkSpawners.SilkSpawners
 version: 1.3
 url: http://dev.bukkit.org/server-mods/silkspawners/
 description: pick up and move monster spawners using silk touch
+softdepend: [Spout]
 commands:
     silkspawners:
         aliases: [silkspawner, ss, spawner]


### PR DESCRIPTION
Displays a notification to the user when a monster spawner is clicked in an inventory, displaying the spawner type to the user.
Same with when switching the spawner to in hand.
Integrated Spout, achievement windows are used to display the info.
Added config option to enable/disable spout/onclick/onhold.
Fixed imports.
Fixed all warnings.
